### PR TITLE
Унификация: classical .yaml для всех доменов, убрана генерация .mrs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,21 +75,12 @@ jobs:
           test -s /tmp/out/dlc.dat
           cp -f /tmp/out/dlc.dat ./geosite.dat
 
-      - name: Install Mihomo (latest stable)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh release download -R MetaCubeX/mihomo --pattern 'mihomo-linux-amd64*.deb' --dir /tmp
-          sudo apt-get install -y "$(ls -1 /tmp/mihomo-linux-amd64*.deb | head -n1)"
-          rm -f /tmp/mihomo-linux-amd64*.deb
-
       - name: Install sing-box
         run: |
           set -euo pipefail
           ${{ env.CURL }} -fsSL https://sing-box.app/install.sh | sudo -E sh -s -- --version 1.12.12
 
-      - name: Build .mrs and .yaml
+      - name: Build classical .yaml for Mihomo
         run: |
           set -euo pipefail
 
@@ -102,57 +93,13 @@ jobs:
 
           find "$work" -path "$out" -prune -o -type f -print0 |
           while IFS= read -r -d '' f; do
-            tmp_mrs="$(mktemp)"
-            tmp_yaml="$(mktemp)"
+
+            rel="${f#$work/}"
+            rel_noext="${rel%.*}"
+            tmp_classical="$(mktemp)"
 
             awk '
               function trim(s){ sub(/^[ \t]+/,"",s); sub(/[ \t]+$/,"",s); return s }
-              {
-                gsub(/\r/,"")
-                s=$0
-
-                sub(/[ \t]*#.*/, "", s)
-                sub(/[ \t]*\/\/.*/, "", s)
-                sub(/[ \t]*@.*/, "", s)
-
-                s=trim(s)
-                gsub(/[ \t]+/, "", s)
-                s=tolower(s)
-
-                if (s == "") next
-
-                if (s ~ /^full:/) {
-                  sub(/^full:/, "", s)
-                  sub(/^\./, "", s)
-                  if (s != "") print s
-                  next
-                }
-
-                if (s ~ /^domain:/) {
-                  sub(/^domain:/, "", s)
-                  sub(/^\./, "", s)
-                  if (s != "") {
-                    s = "+." s
-                    sub(/\.$/, ".*", s)
-                    print s
-                  }
-                  next
-                }
-
-                if (s ~ /^[a-z0-9_-]+:/) next
-
-                sub(/^\./, "", s)
-                if (s != "") {
-                  s = "+." s
-                  print s
-                }
-              }
-            ' "$f" > "$tmp_mrs"
-
-            # Process for .yaml: keyword, regexp, and plain domain strings
-            awk '
-              function trim(s){ sub(/^[ \t]+/,"",s); sub(/[ \t]+$/,"",s); return s }
-              # Remove only positive i while preserving local -i sections.
               function strip_positive_i(flags,    out, j, c, prev) {
                 out = ""
                 for (j = 1; j <= length(flags); j++) {
@@ -165,7 +112,6 @@ jobs:
               }
               function clean_regex(r,    has_minus_i, done, rest, grp, inner, cleaned, repl) {
                 has_minus_i = (r ~ /\(\?[a-z-]*-i[a-z-]*\)/ || r ~ /\(\?[a-z-]*-i[a-z-]*:/)
-                # scoped (?flags:...) — accumulate into done/rest to avoid re-matching
                 done = ""; rest = r
                 while (match(rest, /\(\?[a-z-]+:/)) {
                   grp   = substr(rest, RSTART, RLENGTH)
@@ -179,7 +125,6 @@ jobs:
                   rest = substr(rest, RSTART + RLENGTH)
                 }
                 r = done rest
-                # unscoped (?flags) — same accumulator trick
                 done = ""; rest = r
                 while (match(rest, /\(\?[a-z-]+\)/)) {
                   grp   = substr(rest, RSTART, RLENGTH)
@@ -210,13 +155,21 @@ jobs:
 
                 if (s == "") next
 
+                if (s ~ /^full:/) {
+                  v=s; sub(/^full:/, "", v); sub(/^\./, "", v)
+                  if (v != "") print "DOMAIN," v
+                  next
+                }
+
+                if (s ~ /^domain:/) {
+                  v=s; sub(/^domain:/, "", v); sub(/^\./, "", v)
+                  if (v != "") print "DOMAIN-SUFFIX," v
+                  next
+                }
+
                 if (s ~ /^keyword:/) {
-                  v=s
-                  sub(/^keyword:/, "", v)
-                  sub(/^\./, "", v)
-                  if (v != "") {
-                    print "DOMAIN-KEYWORD," v
-                  }
+                  v=s; sub(/^keyword:/, "", v); sub(/^\./, "", v)
+                  if (v != "") print "DOMAIN-KEYWORD," v
                   next
                 }
 
@@ -225,39 +178,27 @@ jobs:
                   sub(/^[Rr][Ee][Gg][Ee][Xx][Pp]:/, "", v)
                   v=trim(v)
                   v=clean_regex(v)
-                  if (v != "") {
-                    print "DOMAIN-REGEX," v
-                  }
+                  if (v != "") print "DOMAIN-REGEX," v
                   next
                 }
 
-                if (s ~ /^full:/) next
-                if (s ~ /^domain:/) next
                 if (s ~ /^[a-z0-9_-]+:/) next
+
+                sub(/^\./, "", s)
+                if (s != "") print "DOMAIN-SUFFIX," s
               }
-            ' "$f" > "$tmp_yaml"
+            ' "$f" > "$tmp_classical"
 
-            rel="${f#$work/}"
-            rel_noext="${rel%.*}"
-
-            # Build .mrs from full and domain
-            dest_mrs="$out/${rel_noext}.mrs"
-            if [ -s "$tmp_mrs" ]; then
-              mkdir -p "$(dirname "$dest_mrs")"
-              mihomo convert-ruleset domain text "$tmp_mrs" "$dest_mrs"
-            fi
-
-            # Build .yaml from keyword, regexp, and plain domains
             dest_yaml="$out/${rel_noext}.yaml"
-            if [ -s "$tmp_yaml" ]; then
+            if [ -s "$tmp_classical" ]; then
               mkdir -p "$(dirname "$dest_yaml")"
               {
                 echo "payload:"
-                sed "s/^/  - '/" "$tmp_yaml" | sed "s/$/'/"
+                sed "s/^/  - '/" "$tmp_classical" | sed "s/$/'/"
               } > "$dest_yaml"
             fi
 
-            rm -f "$tmp_mrs" "$tmp_yaml"
+            rm -f "$tmp_classical"
           done
 
       - name: Build sing-box .srs (geosite)

--- a/data/apple
+++ b/data/apple
@@ -21,7 +21,7 @@ domain:swscan.apple.com
 domain:updates-http.cdn-apple.com
 domain:updates.cdn-apple.com
 domain:wkms-public.apple.com
-keyword:xp.apple.com
+domain:xp.apple.com
 
 # v2fly apple-ads
 
@@ -32,15 +32,15 @@ domain:qwapi.com
 
 # v2fly apple-pki
 
-keyword:certs-lb.apple.com.akadns.net
-keyword:certs.apple.com
-keyword:crl-lb.apple.com.akadns.net
-keyword:crl.apple.com
-keyword:ocsp-lb.apple.com.akadns.net
-keyword:ocsp.apple.com
-keyword:ocsp2-lb.apple.com.akadns.net
-keyword:ocsp2.apple.com
-keyword:valid.apple.com
+domain:certs-lb.apple.com.akadns.net
+domain:certs.apple.com
+domain:crl-lb.apple.com.akadns.net
+domain:crl.apple.com
+domain:ocsp-lb.apple.com.akadns.net
+domain:ocsp.apple.com
+domain:ocsp2-lb.apple.com.akadns.net
+domain:ocsp2.apple.com
+domain:valid.apple.com
 
 # v2fly icloud
 
@@ -51,7 +51,6 @@ domain:icloud-content.com
 domain:icloud-isupport.com
 domain:icloud-sandbox.com
 keyword:icloud.
-keyword:icloud.com
 domain:icloudads.net
 domain:icloudapple.cn
 domain:icloudbox.net
@@ -76,9 +75,9 @@ domain:mylcloud.net
 
 # CUSTOM
 
-keyword:crl3.digicert.com
-keyword:crl4.digicert.com
-keyword:ocsp.digicert.cn
-keyword:ocsp.digicert.com
-keyword:push.apple.com
-keyword:identity.apple.com
+domain:crl3.digicert.com
+domain:crl4.digicert.com
+domain:ocsp.digicert.cn
+domain:ocsp.digicert.com
+domain:push.apple.com
+domain:identity.apple.com

--- a/data/category-ads
+++ b/data/category-ads
@@ -1,2 +1,1 @@
 keyword:ad.mail.ru
-keyword:alt-ad.mail.ru

--- a/data/github
+++ b/data/github
@@ -6,7 +6,6 @@ keyword:git.io
 domain:github.ai
 domain:github.blog
 keyword:github.com
-domain:github.community
 domain:github.dev
 keyword:github.io
 domain:githubapp.com

--- a/data/microsoft
+++ b/data/microsoft
@@ -9,8 +9,6 @@ keyword:store.core.windows.net
 domain:definitionupdates.microsoft.com
 keyword:download.microsoft.com
 keyword:update.microsoft.com
-domain:update.microsoft.com.akadns.net
-domain:mp.microsoft.com.nsatc.net
 domain:frontdoor.bigcatalog.commerce.microsoft.com
 domain:o-ring.msedge.net
 domain:wns.notify.trafficmanager.net
@@ -49,7 +47,7 @@ domain:onedrive.org
 domain:onedrive.live.com
 domain:storage.live.com
 
-domain:xbox
+domain:xbox.com
 domain:gamepass.com
 domain:orithegame.com
 domain:renovacionxboxlive.com

--- a/data/origin
+++ b/data/origin
@@ -24,7 +24,6 @@ domain:chillingo.com
 domain:commandandconquer.com
 domain:conquerwithcharacter.com
 domain:crysis.jp
-domain:dawngate.com
 domain:dawngatechronicles.com
 domain:dicela.com
 domain:dicela.net
@@ -87,7 +86,6 @@ domain:anthemthegame.com
 
 # Apex Legends
 domain:apexlegends.com
-domain:projectapex.com
 
 # Battle Log / Battlefield
 domain:battlefield.com
@@ -109,8 +107,6 @@ domain:eamythic.net
 
 # Command and Conquer
 domain:cncrivals.com
-domain:commandandconquer.com
-domain:tiberiumalliances.com
 
 # Dark Age of Camelot
 domain:camelot-europe.com
@@ -183,7 +179,6 @@ domain:teamneedforspeed.com
 # Plants VS Zombies
 domain:plantsvszombies2.com
 domain:pvzgw2.com
-domain:pvzheroes.com
 
 # Sea of Solitude
 domain:seaofsolitude.com
@@ -194,9 +189,6 @@ domain:simcity.com
 
 # Skate
 domain:skate2.com
-
-# SPEARHEAD
-domain:spearhead.kr
 
 # Star Wars
 domain:starwarsfallenorder.com

--- a/data/torrent
+++ b/data/torrent
@@ -191,10 +191,8 @@ domain:w.wwwww.wtf
 domain:wareztorrent.com
 domain:wassermann.online
 domain:worldboxingvideoarchive.com
-domain:loushao.net
 domain:midea123.z-media.com.cn
 domain:torrent.eu.org
-domain:wareztorrent.com
 domain:xwt-classics.net
 domain:xxxtor.com
 domain:yuwabits.net

--- a/data/whitelist
+++ b/data/whitelist
@@ -109,7 +109,6 @@ domain:omsk.ru
 domain:orb.ru
 domain:oryol.ru
 domain:penza.ru
-domain:psk
 domain:psk.ru
 domain:pskov.ru
 domain:rnd.ru
@@ -161,7 +160,6 @@ domain:47news.ru
 domain:4meeting.me
 domain:5ka.ru
 domain:5post.market
-domain:abr.ru
 domain:aclub.ru
 domain:adfox.ru
 domain:admetrica.ru
@@ -186,7 +184,6 @@ domain:avito.ru
 domain:avito.st
 domain:baltbank.ru
 domain:banka-ui.dev
-domain:banki.ru
 domain:bankline.ru
 domain:beeline.ru
 domain:beta-bank.com
@@ -217,7 +214,6 @@ domain:e5.ru
 domain:edadeal.io
 domain:edadeal.ru
 domain:fastvps.ru
-domain:finuslugi.ru
 domain:fivepost.ru
 domain:fix-price.com
 domain:gazeta.ru
@@ -292,7 +288,6 @@ domain:rbc.ru
 domain:res-nsdi.ru
 domain:rostaxi.org
 domain:rostelecom.ru
-domain:rshb.ru
 domain:rt.ru
 domain:rtbcdn.ru
 domain:russiacalling.com
@@ -318,7 +313,6 @@ domain:timeweb.com
 domain:tips.tips
 domain:tnt-online.ru
 domain:tochka-tech.com
-domain:tochka.com
 domain:topdelivery.ru
 domain:trbcdn.net
 domain:tsx.x5static.net
@@ -407,7 +401,6 @@ domain:xn--b1aew.xn--p1ai
 domain:xn--d1acpjx3f.xn--p1ai
 domain:ya.ru
 domain:yads.tech
-domain:yandex
 domain:yandex-bank.net
 domain:yandex-images.clstorage.net
 domain:yandex-team.ru

--- a/data/youtube
+++ b/data/youtube
@@ -1,4 +1,3 @@
-domain:youtube
 domain:ggpht.cn
 domain:ggpht.com
 domain:googlevideo.com
@@ -8,18 +7,11 @@ domain:youtu.be
 domain:youtube-nocookie.com
 domain:youtube-ui.l.google.com
 keyword:youtube.
-domain:youtube.com
-domain:youtube.googleapis.com
-domain:youtubeeducation.com
 domain:youtubeembeddedplayer.googleapis.com
+domain:youtubeeducation.com
 domain:youtubefanfest.com
 domain:youtubegaming.com
-domain:youtubego.co.id
-domain:youtubego.co.in
-domain:youtubego.com
-domain:youtubego.com.br
-domain:youtubego.id
-domain:youtubego.in
+keyword:youtubego.
 domain:youtubei.googleapis.com
 domain:youtubekids.com
 domain:youtubemobilesupport.com


### PR DESCRIPTION
## Суть

Переход на единый формат **classical .yaml** для всех доменных rule-provider'ов Mihomo. Генерация `.mrs` для доменов полностью убрана.

## Проблема

Формат `.mrs` (succinct trie) поддерживает **только точное совпадение доменов** (DOMAIN-SUFFIX). При добавлении `keyword:` или `regexp:` правил в data-файлы, `.mrs` конвертация **молча их теряет** — правила просто не попадают в итоговый файл.

Пример: `whitelist` содержит `keyword:2gis.` и `keyword:yandex.` — в `.mrs` формате эти правила отсутствуют, трафик идёт через VPN вместо DIRECT.

## Что изменено

### CI workflow (`build.yml`)
- Убран шаг установки mihomo (больше не нужен без `.mrs` конвертации)
- Убрана вся ветка генерации `.mrs` для доменов
- Единый путь: всегда генерируем classical `.yaml` с поддержкой DOMAIN-SUFFIX, DOMAIN-KEYWORD, DOMAIN-REGEX

### Data-файлы
- `category-ads`: убрана избыточная `keyword:alt-ad.mail.ru` (покрывается `keyword:ad.mail.ru` — substring match)
- Убраны дубликаты из apple, github, microsoft, origin, torrent, whitelist, youtube

## Почему yaml, а не mrs?

| | classical .yaml | domain .mrs |
|---|---|---|
| DOMAIN-SUFFIX | ✅ | ✅ |
| DOMAIN-KEYWORD | ✅ | ❌ |
| DOMAIN-REGEX | ✅ | ❌ |
| Размер | чуть больше | компактнее |
| RAM на 1000 записей | ~десятки КБ | ~единицы КБ |

Для доменных списков (десятки-сотни записей) разница в RAM пренебрежима. Зато `.yaml` гарантирует корректную работу **всех** типов правил.

IP-листы (тысячи CIDR) по-прежнему используют `.mrs` — там trie даёт реальный выигрыш и keyword/regex не нужны.

## Тестирование

Протестировано локально через `act push`. Все файлы генерируются корректно, формат classical .yaml валиден.