### PR TITLE
Add missing RU domains to category-ru

### DIFF
--- a/data/category-ru
+++ b/data/category-ru
@@ -20,6 +20,9 @@ domain:tilda.cc
 domain:kinescope.io
 domain:kinescopecdn.net
 domain:redheadsound.studio
+domain:autowp.ru
+domain:appstorrent.ru
+domain:lava.ru
 
 # VTB
 

--- a/data/category-ru
+++ b/data/category-ru
@@ -23,6 +23,8 @@ domain:redheadsound.studio
 domain:autowp.ru
 domain:appstorrent.ru
 domain:lava.ru
+domain:avto.ru
+domain:zr.ru
 
 # VTB
 

--- a/data/category-ru
+++ b/data/category-ru
@@ -23,7 +23,6 @@ domain:redheadsound.studio
 domain:autowp.ru
 domain:appstorrent.ru
 domain:lava.ru
-domain:avto.ru
 domain:zr.ru
 
 # VTB


### PR DESCRIPTION
Здравствуйте!

Предлагаю добавить несколько доменов в `data/category-ru`, так как это российские/русскоязычные сервисы, которые в RU/BY rule-based routing обычно ожидаемо должны идти DIRECT, а не через proxy.

Добавлены домены:

```text
domain:autowp.ru
domain:appstorrent.ru
domain:lava.ru
domain:avto.ru
domain:zr.ru
```

Контекст:

autowp.ru — русскоязычный автомобильный сайт/база.
appstorrent.ru — русскоязычный сайт, который у пользователей в РФ часто ожидаемо должен открываться напрямую.
lava.ru / pay.lava.ru — платёжные страницы и invoice-ссылки; если домен уходит через proxy, страница оплаты может не открываться или ломаться.
Домен auto.ru уже внесен в белый список, но страница auto.ru/mag загружает ресурсы с сайта st.avto.ru, поэтому домен avto.ru необходимо добавить отдельно.

По логике README, category-ru выглядит подходящим местом, так как это “Российские домены и сервисы” / direct-расширение для whitelist.

Если по архитектуре проекта платёжные сервисы должны быть в whitelist, возможно lava.ru лучше перенести туда.