### PR TITLE
Add more RU service domains to category-ru

### DIFF
--- a/data/category-ru
+++ b/data/category-ru
@@ -20,6 +20,13 @@ domain:tilda.cc
 domain:kinescope.io
 domain:kinescopecdn.net
 domain:redheadsound.studio
+domain:happ.su
+domain:happ.info
+domain:aliexpress.ru
+domain:rdp-onedash.ru
+domain:aviasales.ru
+domain:aviasales.com
+domain:usmall.ru
 
 # VTB
 


### PR DESCRIPTION
Добавляю несколько российских/русскоязычных сервисов в category-ru, чтобы они шли DIRECT в rule-based routing.

Домены:
- domain:happ.su
- domain:happ.info
- domain:aliexpress.ru
- domain:rdp-onedash.ru
- domain:aviasales.ru
- domain:aviasales.com
- domain:usmall.ru