### PR TITLE
data: add push category (Android/FCM + connectivity checks)

### DIFF
--- a/data/push
+++ b/data/push
@@ -1,0 +1,28 @@
+# Push notifications and connectivity checks for mobile clients.
+#
+# These must stay DIRECT: routing them through a tunnel adds delivery latency,
+# and when the VPN drops the user simply stops receiving notifications and
+# blames the app. Apple hosts already live in `apple`; this file adds the
+# Android/FCM side, which was missing, plus the OS connectivity probes that
+# make the system show "no internet" when they fail.
+
+# Android / FCM
+domain:mtalk.google.com
+domain:mtalk4.google.com
+domain:alt1-mtalk.google.com
+domain:alt2-mtalk.google.com
+domain:alt3-mtalk.google.com
+domain:alt4-mtalk.google.com
+domain:alt5-mtalk.google.com
+domain:alt6-mtalk.google.com
+domain:alt7-mtalk.google.com
+domain:alt8-mtalk.google.com
+domain:android.clients.google.com
+domain:device-provisioning.googleapis.com
+domain:fcm.googleapis.com
+domain:firebaseinstallations.googleapis.com
+
+# Connectivity checks (system shows "no internet" without them)
+domain:connectivitycheck.gstatic.com
+domain:connectivitycheck.android.com
+domain:time.android.com


### PR DESCRIPTION
Привет! Спасибо за списки — пользуемся ими в мобильном VPN-клиенте на xray.

## Проблема

В geosite нет хостов пуш-уведомлений Android. Проверил по всем 23 категориям:

- `wns.windows.com` (Windows) — есть, в `microsoft`
- `push.apple.com`, `captive.apple.com` (iOS) — есть, в `apple`
- FCM (Android) — **нет нигде**

Из-за этого на Android пуши идут через туннель. Это добавляет задержку доставки, а при обрыве VPN уведомления просто перестают приходить — и пользователь думает, что сломалось приложение, а не VPN.

## Что предлагаю

Новая категория `push` — отдельная, а не дописать в существующую, потому что единственная подходящая по смыслу (`google-play`) лежит в `ProxySites`, то есть принудительно в туннель. А `push` пригодится любому мобильному клиенту.

Кроме FCM добавил проверки связности: без них система рисует «нет интернета», даже когда всё работает.

Сборка копирует весь `data/` в компилятор v2fly, так что новый файл подхватывается сам — реестр править не нужно.

Отдельный PR в `roscomvpn-routing` добавит `geosite:push` в `DirectSites` профилей DEFAULT и WHITELIST.

## Ещё вопрос, если можно

В `roscomvpn-geoip` нет файла LICENSE (здесь, в geosite, MIT есть). Мы хотим вложить ваши .dat внутрь приложения в App Store. В чате вы написали «пользуйтесь» — спасибо; не могли бы вы добавить LICENSE в geoip, чтобы условия были зафиксированы явно? Так спокойнее и вам, и всем, кто вас использует.